### PR TITLE
Fix: Remove deprecated homebrew/cask-fonts tap

### DIFF
--- a/scripts/bootstrap-macos.sh
+++ b/scripts/bootstrap-macos.sh
@@ -187,9 +187,21 @@ else
   ok "Homebrew environment persisted in shell profiles"
 fi
 
+# Remove deprecated taps
+log "Cleaning up deprecated taps..."
+if [[ "$DRY_RUN" == "true" ]]; then
+  log "[DRY RUN] Would remove deprecated homebrew/cask-fonts tap if present"
+else
+  if brew tap | grep -qx "homebrew/cask-fonts"; then
+    log "Removing deprecated homebrew/cask-fonts tap (fonts are now in homebrew/cask)"
+    brew untap homebrew/cask-fonts
+  else
+    ok "Deprecated homebrew/cask-fonts tap not present"
+  fi
+fi
+
 # Add required taps
 log "Adding required Homebrew taps..."
-ensure_tap "homebrew/cask-fonts"
 ensure_tap "jandedobbeleer/oh-my-posh"
 ensure_tap "homebrew/autoupdate"
 


### PR DESCRIPTION
## 🐛 Problem

The bootstrap script was failing on fresh macOS installations due to the deprecated \`homebrew/cask-fonts\` tap. This tap has been deprecated and is now empty, causing the script to fail when trying to add it.

## 🔧 Solution

- **Removed** the deprecated \`homebrew/cask-fonts\` tap from the bootstrap script
- **Added** cleanup logic to automatically remove the deprecated tap if it already exists on the system
- **Verified** that font installations (like \`font-hack-nerd-font\`) still work without the separate fonts tap
- **Confirmed** fonts are now available in the main \`homebrew/cask\` repository

## ✅ Testing

- ✅ Script runs successfully with \`--dry-run\` mode
- ✅ Font casks are available from the main cask repository  
- ✅ Existing font installations are not affected
- ✅ Bootstrap script completes without errors

## 📋 Changes

- Removed \`ensure_tap "homebrew/cask-fonts"\` from the tap setup section
- Added deprecation cleanup logic that removes the tap if present
- Updated comments to reflect that fonts are now in the main cask repository

Closes #7