### PR TITLE
CI: Add additional macOS versions to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
     strategy:
       matrix:
         # Test on different macOS versions if available
-        os-version: [macos-13, macos-14]
+        os-version: [macos-13, macos-14, macos-15, macos-26]
     continue-on-error: true  # Don't fail if some versions aren't available
     
     steps:


### PR DESCRIPTION
## 🚀 Enhancement

Expand CI test coverage by adding more macOS versions to the GitHub Actions workflow matrix.

## 📋 Changes

- **Added** \`macos-15\` to the test matrix for testing on macOS Sequoia
- **Added** \`macos-26\` to the test matrix for future macOS versions
- **Maintained** existing \`continue-on-error: true\` to gracefully handle versions that may not be available yet

## ✅ Benefits

- **Broader compatibility testing** across multiple macOS versions
- **Future-proofing** the CI pipeline for upcoming macOS releases
- **Early detection** of compatibility issues on newer macOS versions
- **Robust error handling** for unavailable runner versions

## 🔧 Technical Details

The workflow matrix now tests on:
- \`macos-13\` (macOS Ventura)
- \`macos-14\` (macOS Sonoma) 
- \`macos-15\` (macOS Sequoia)
- \`macos-26\` (Future macOS version)

The \`continue-on-error: true\` setting ensures the workflow doesn't fail if GitHub Actions doesn't have certain macOS versions available yet.